### PR TITLE
Update mkarray to use the re-entrant safe strtok_r rather than strtok.

### DIFF
--- a/openarc/util.c
+++ b/openarc/util.c
@@ -874,9 +874,10 @@ arcf_inet_ntoa(struct in_addr a, char *buf, size_t buflen)
 const char **
 arcf_mkarray(char *in)
 {
-	int c;
+	int c = 0;
 	int n = 1;
 	char *p;
+	char *ctx;
 	char **out = NULL;
 
 	assert(in != NULL);
@@ -891,9 +892,9 @@ arcf_mkarray(char *in)
 	if (out == NULL)
 		return (const char **) NULL;
 
-	for (p = strtok(in, ","); *p != '\0'; p = strtok(NULL, ","))
-		out[c] = p;
-	out[c] = NULL;
+	for (p = strtok_r(in, ",", &ctx); p != NULL; p = strtok_r(NULL, ",", &ctx))
+		out[c++] = p;
+	out[n] = NULL;
 
 	return (const char **) out;
 }


### PR DESCRIPTION
Uses strtok_r rather than strtok.  Also initializes the value of the loop variable c.